### PR TITLE
Add gulp help function for task listing.

### DIFF
--- a/gulp/tasks/help.js
+++ b/gulp/tasks/help.js
@@ -1,0 +1,21 @@
+'use strict';
+
+var gulp = require('gulp'),
+    taskListing = require('gulp-task-listing');
+
+module.exports = function() {
+
+    var exclude = [
+        'server', // exclude main- and sub tasks
+        'test:' // exclude sub tasks
+    ];
+
+    gulp.task('help', taskListing.withFilters(null, function(task) {
+        for (let i = 0; i < exclude.length; i++) {
+            if (task.indexOf(exclude[i]) !== -1) {
+                return true;
+            }
+        }
+    }));
+
+};

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "gulp-strip-css-comments": "^1.2.0",
     "gulp-svgmin": "^1.2.3",
     "gulp-svgstore": "^6.1.0",
+    "gulp-task-listing": "^1.0.1",
     "gulp-uglify": "^2.0.0",
     "gulp-watch": "^4.3.11",
     "iedriver": "^3.0.0",


### PR DESCRIPTION
Simple `gulp help` function to list all available main- and sub tasks. Config available in `help.js`, to exclude main and/or subtasks.

@roccojanse, can you configure which ones to exclude?

One 'to do' off the list, what a relief...

![one less to do](https://media3.giphy.com/media/j0Xxo0JuvDtCw/giphy.gif)